### PR TITLE
「未対応のメソッドです」というテキストを返すように実装

### DIFF
--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -22,7 +22,8 @@ function handleBadRequest(req, res) {
     'charset': 'utf-8'
   });
   res.end('未対応のメゾットです');
-}    
+}
+    
 module.exports = {
   handleLogout: handleLogout,
   handleNotFound: handleNotFound,

--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -16,7 +16,15 @@ function handleNotFound(req, res) {
   res.end('ページがみつかりません');
 }
 
+function handleBadRequest(req, res) {
+  res.writeHead(400, {
+    'Content-Type':'text/plain',
+    'charset': 'utf-8'
+  });
+  res.end('未対応のメゾットです');
+}    
 module.exports = {
   handleLogout: handleLogout,
-  handleNotFound: handleNotFound
+  handleNotFound: handleNotFound,
+  handleBadRequest: handleBadRequest
 };

--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -18,7 +18,7 @@ function handleNotFound(req, res) {
 
 function handleBadRequest(req, res) {
   res.writeHead(400, {
-    'Content-Type':'text/plain',
+    'Content-Type': 'text/plain',
     'charset': 'utf-8'
   });
   res.end('未対応のメゾットです');

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -1,5 +1,6 @@
 'use strict';
 const jade = require('jade');
+const util = require('./handler-util');
 const contents = [];
 
 function handle(req, res) {
@@ -22,6 +23,7 @@ function handle(req, res) {
       });
       break;
     default:
+      util.handleBadRequest(req, res);   
       break;
   }
 }


### PR DESCRIPTION
一度目　push後に　文字の位置かちがうことに　きずき　直し　再pushを　だけど　さらに　直す所が見つかりました　その後　再push　二回直しています。pushする前　に　誤字など　ないか　もっと確認します。本当に　申し訳ありません。直したところは　一度目は　　
①Content-Type':'text/plain',を'Content-Type': 'text/plain',に 直し 
2度目は
② res.end('未対応のメゾットです');
}　より	下
 1行 あけていませんでしたので　あけました。　
練習用なので　マージは不要です。