### PR TITLE
未対応メソッドへの対応

### DIFF
--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -1,5 +1,13 @@
 'use strict';
 
+function handleBadRequest(req, res) {
+  res.writeHead(400, {
+    'Content-Type': 'text/plain',
+    'charset': 'utf-8'
+  });
+  res.end('未対応のメソッドです');
+}
+
 function handleLogout(req, res) {
   res.writeHead(401, {
     'Content-Type': 'text/plain',
@@ -17,6 +25,7 @@ function handleNotFound(req, res) {
 }
 
 module.exports = {
+  handleBadRequest: handleBadRequest,
   handleLogout: handleLogout,
   handleNotFound: handleNotFound
 };

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -22,7 +22,7 @@ function handle(req, res) {
       });
       break;
     default:
-      break;
+      return 400;
   }
 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,15 +5,15 @@ const util = require('./handler-util');
 function route(req, res) {
   switch (req.url) {
     case '/posts':
-      postsHandler.handle(req, res);
+      const number = postsHandler.handle(req, res);
+      if (number === 400) util.handleBadRequest(req, res);
       break;
     case '/logout':
       util.handleLogout(req, res);
       break;
     default:
       util.handleNotFound(req, res);
-      break;
-  }
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
模範解答と違うのは、なんとなくhandler-utilを二か所から呼び出したくなかったから…Cの#includeみたいな結合イメージで、重複する気がしたんだけど、スクリプト言語でのrequireはただの参照みたいな感じで関係ないのか…
それを避けるために、posts-handler.handleに戻り値を設定するという勝手な改変をしてしまった(しかもBad Request以外はまともな値を返さない)ので、こっちの方が罪が重いかもしれない。