### PR TITLE
対応されていないメソッドのリクエストが来た際に、 400 - Bad Request というステータスコードを返し、「未対応のメソッドです…

### DIFF
--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -14,7 +14,15 @@ function handleNotFound(req, res) {
   res.end('ページがみつかりません');
 }
 
+function handleBadRequest(req, res) {
+  res.writeHead(400, {
+    'Content-Type': 'text/plain; charset=utf-8'
+  });
+  res.end('未対応のメソッドです')
+}
+
 module.exports = {
   handleLogout: handleLogout,
-  handleNotFound: handleNotFound
+  handleNotFound: handleNotFound,
+  handleBadRequest: handleBadRequest
 };

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -1,5 +1,6 @@
 'use strict';
 const pug = require('pug');
+const util = require('./handler-util');
 const contents = [];
 
 function handle(req, res) {
@@ -25,6 +26,7 @@ function handle(req, res) {
       });
       break;
     default:
+      util.handleBadRequest(req, res);
       break;
   }
 }


### PR DESCRIPTION
…」というテキストを返すように実装