### PR TITLE
handleBadRequest関数の実装

### DIFF
--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -14,7 +14,16 @@ function handleNotFound(req, res) {
   res.end('ページがみつかりません');
 }
 
+// ステータスコード400: 未対応のメソッドが来た時の関数
+function handleBadRequest(req, res) {
+  res.writeHead(400, {
+  'Content-Type': 'text/plain; charset=utf-8'
+  });
+  res.end('未対応のメソッドです')
+}
+
 module.exports = {
   handleLogout: handleLogout,
-  handleNotFound: handleNotFound
+  handleNotFound: handleNotFound,
+  handleBadRequest: handleBadRequest
 };

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -1,5 +1,6 @@
 'use strict';
 const pug = require('pug');
+const util = require('./handler-util')
 const contents = [];
 
 function handle(req, res) {
@@ -25,6 +26,8 @@ function handle(req, res) {
       });
       break;
     default:
+      // そのメソッドに対する処理が未実装だった場合、ステータスコード400を返す
+      util.handleBadRequest(req, res);
       break;
   }
 }


### PR DESCRIPTION
handleBadRequest関数を実装しました。
- 受け取ったメソッドが未対応だった場合の処理をします
- レスポンスとして、ステータスコード400と「未対応のメソッドです」という文字列を返します