### PR TITLE
対応されていないメソッドのリクエストが来た際に、 400 - Bad Request というステータスコードを返し、 「未対応のメソッドで…

### DIFF
--- a/lib/handler-util.js
+++ b/lib/handler-util.js
@@ -14,7 +14,15 @@ function handleNotFound(req, res) {
   res.end('ページがみつかりません');
 }
 
+function handleBadRequest(req, res) {
+  res.writeHead(400, {
+      'Content-Type': 'text/plain; charset=utf-8'
+  });
+  res.end('未対応のメソッドです');
+}
+
 module.exports = {
   handleLogout,
-  handleNotFound
+  handleNotFound,
+  handleBadRequest
 };

--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -1,5 +1,6 @@
 'use strict';
 const pug = require('pug');
+const handler = require('./handler-util.js');
 const contents = [];
 
 function handle(req, res) {
@@ -25,7 +26,7 @@ function handle(req, res) {
       });
       break;
     default:
-      break;
+      handler.handleBadRequest(req, res);
   }
 }
 


### PR DESCRIPTION
…す」というテキストを返すように実装